### PR TITLE
build: Add linting tools and code quality checks to Makefile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,10 +105,10 @@ docker-compose up -d mysql
 # Run migrations and seeding
 go run cmd/seeder/seeder.go
 
-# Start server (default port 8080)
+# Start server (default port 3000)
 go run cmd/server/main.go
 
-# Server runs on http://localhost:8080
+# Server runs on http://localhost:3000
 ```
 
 ## Key Architectural Patterns


### PR DESCRIPTION
## Changes

This PR adds comprehensive code quality and linting infrastructure to streamline the development workflow:

### Updates to Makefile:
- **Added `golangci-lint` installation** in `install-tools` target with version v1.62.2
- **New `lint` target**: Runs golangci-lint with a 7-minute timeout, excluding cmd, docs, and tests directories
- **New `fmt` target**: Runs `go fmt` for consistent code formatting
- **New `vet` target**: Runs `go vet` for static analysis
- **New `pre-push` target**: Composite target that runs fmt → vet → lint → test in sequence to ensure code quality before pushing

### Documentation Updates:
- Fixed default server port from 8080 to 3000 in Copilot instructions
- Updated server URL examples in `.github/copilot-instructions.md`

## Benefits

- **Improved code quality**: Automated linting and formatting checks catch issues early
- **Consistent development workflow**: Pre-push checks prevent poorly formatted or problematic code from being committed
- **Better CI/CD integration**: Developers can run the same checks locally as CI would run
- **Maintainability**: Clear targets in Makefile document the code quality expectations

## Testing

All new Makefile targets have been verified to work correctly with the existing project structure.