### PR TITLE
feat: Enhance MFA error handling with dedicated error types

### DIFF
--- a/internal/handlers/mfa_handler.go
+++ b/internal/handlers/mfa_handler.go
@@ -66,7 +66,7 @@ func (h *MfaHandler) InitMfaSetup(c *gin.Context) {
 	secret, qrCodeBytes, backupCodes, err := h.mfaService.SetupMfa(userID, input.Email)
 	if err != nil {
 		logrus.Errorf("Failed to setup MFA for user %d: %v", userID, err)
-		utils.RespondWithError(c, apperror.NewInternalError("Failed to setup MFA"))
+		utils.RespondWithError(c, err)
 		return
 	}
 

--- a/pkg/apperror/codes.go
+++ b/pkg/apperror/codes.go
@@ -33,4 +33,14 @@ const (
 	ErrCacheDelete = 4004 // Delete cache error
 	ErrCacheList   = 4005 // List cache error
 	ErrCacheExists = 4006 // Cache key exists check error
+
+	// MFA errors
+	ErrMfaAlreadyEnabled    = 5000 // MFA is already enabled
+	ErrMfaNotEnabled        = 5001 // MFA is not enabled
+	ErrMfaSetupNotInitiated = 5002 // MFA setup not initiated
+	ErrMfaInvalidCode       = 5003 // Invalid MFA code
+	ErrMfaExpired           = 5004 // MFA session expired
+	ErrMfaSecretGeneration  = 5005 // Failed to generate MFA secret
+	ErrMfaQRCodeGeneration  = 5006 // Failed to generate QR code
+	ErrMfaBackupCodeError   = 5007 // Backup code error
 )

--- a/pkg/apperror/factory.go
+++ b/pkg/apperror/factory.go
@@ -169,3 +169,68 @@ func NewValidationDataError(message string) *AppError {
 		Message:        message,
 	}
 }
+
+// === MFA errors ===
+func NewMfaAlreadyEnabledError(message string) *AppError {
+	return &AppError{
+		HttpStatusCode: http.StatusBadRequest,
+		Code:           ErrMfaAlreadyEnabled,
+		Message:        message,
+	}
+}
+
+func NewMfaNotEnabledError(message string) *AppError {
+	return &AppError{
+		HttpStatusCode: http.StatusBadRequest,
+		Code:           ErrMfaNotEnabled,
+		Message:        message,
+	}
+}
+
+func NewMfaSetupNotInitiatedError(message string) *AppError {
+	return &AppError{
+		HttpStatusCode: http.StatusBadRequest,
+		Code:           ErrMfaSetupNotInitiated,
+		Message:        message,
+	}
+}
+
+func NewMfaInvalidCodeError(message string) *AppError {
+	return &AppError{
+		HttpStatusCode: http.StatusBadRequest,
+		Code:           ErrMfaInvalidCode,
+		Message:        message,
+	}
+}
+
+func NewMfaExpiredError(message string) *AppError {
+	return &AppError{
+		HttpStatusCode: http.StatusBadRequest,
+		Code:           ErrMfaExpired,
+		Message:        message,
+	}
+}
+
+func NewMfaSecretGenerationError(message string) *AppError {
+	return &AppError{
+		HttpStatusCode: http.StatusInternalServerError,
+		Code:           ErrMfaSecretGeneration,
+		Message:        message,
+	}
+}
+
+func NewMfaQRCodeGenerationError(message string) *AppError {
+	return &AppError{
+		HttpStatusCode: http.StatusInternalServerError,
+		Code:           ErrMfaQRCodeGeneration,
+		Message:        message,
+	}
+}
+
+func NewMfaBackupCodeError(message string) *AppError {
+	return &AppError{
+		HttpStatusCode: http.StatusInternalServerError,
+		Code:           ErrMfaBackupCodeError,
+		Message:        message,
+	}
+}

--- a/pkg/apperror/factory_test.go
+++ b/pkg/apperror/factory_test.go
@@ -43,6 +43,16 @@ func TestErrorConstructors(t *testing.T) {
 		// Common errors
 		{"ParseError", NewParseError, ErrParseError, http.StatusBadRequest},
 		{"ValidationDataError", NewValidationDataError, ErrValidationFailed, http.StatusBadRequest},
+
+		// MFA errors
+		{"MfaAlreadyEnabledError", NewMfaAlreadyEnabledError, ErrMfaAlreadyEnabled, http.StatusBadRequest},
+		{"MfaNotEnabledError", NewMfaNotEnabledError, ErrMfaNotEnabled, http.StatusBadRequest},
+		{"MfaSetupNotInitiatedError", NewMfaSetupNotInitiatedError, ErrMfaSetupNotInitiated, http.StatusBadRequest},
+		{"MfaInvalidCodeError", NewMfaInvalidCodeError, ErrMfaInvalidCode, http.StatusBadRequest},
+		{"MfaExpiredError", NewMfaExpiredError, ErrMfaExpired, http.StatusBadRequest},
+		{"MfaSecretGenerationError", NewMfaSecretGenerationError, ErrMfaSecretGeneration, http.StatusInternalServerError},
+		{"MfaQRCodeGenerationError", NewMfaQRCodeGenerationError, ErrMfaQRCodeGeneration, http.StatusInternalServerError},
+		{"MfaBackupCodeError", NewMfaBackupCodeError, ErrMfaBackupCodeError, http.StatusInternalServerError},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Overview
This PR improves MFA (Multi-Factor Authentication) error handling by introducing dedicated error types and codes, replacing generic error responses with specific, actionable MFA-related errors.

## Changes

### MFA Service Improvements (`internal/services/mfa_service.go`)
- **SetupMfa**: Added validation to prevent duplicate MFA setup by checking if MFA is already enabled
- Enhanced error handling with new dedicated MFA error types throughout the service
- Added persistence of TOTP secret and backup codes to database during setup
- Replaced generic `UnauthorizedError` and `InvalidPasswordError` with specific MFA errors:
  - `NewMfaSetupNotInitiatedError` for expired/uninitialized MFA setup
  - `NewMfaInvalidCodeError` for invalid TOTP codes
  - `NewMfaNotEnabledError` for disabled MFA scenarios

### Error Handling (`pkg/apperror/`)
- **codes.go**: Added 8 new MFA-specific error codes (5000-5007):
  - `ErrMfaAlreadyEnabled`, `ErrMfaNotEnabled`, `ErrMfaSetupNotInitiated`
  - `ErrMfaInvalidCode`, `ErrMfaExpired`, `ErrMfaSecretGeneration`
  - `ErrMfaQRCodeGeneration`, `ErrMfaBackupCodeError`

- **factory.go**: Implemented 8 new error factory functions with appropriate HTTP status codes:
  - Client errors (400): Already enabled, not enabled, setup not initiated, invalid code, expired
  - Server errors (500): Secret generation, QR code generation, backup code errors

- **factory_test.go**: Added comprehensive tests for all new MFA error constructors

### Handler Updates (`internal/handlers/mfa_handler.go`)
- Modified `InitMfaSetup` to return actual error instead of generic internal error
- Added test case for MFA already enabled scenario

## Benefits
✅ Better error differentiation for MFA operations
✅ More specific HTTP status codes (400 for client errors, 500 for server errors)
✅ Improved API client experience with distinct error codes
✅ Prevention of duplicate MFA setup attempts
✅ Reduced reliance on generic error types

## Testing
- All existing tests pass
- New test case validates MFA already enabled error scenario
- MFA error factory functions thoroughly tested

## Files Changed
- `internal/handlers/mfa_handler.go` (2 lines ±)
- `internal/handlers/mfa_handler_test.go` (+33 lines)
- `internal/services/mfa_service.go` (+47 lines, -6 lines)
- `pkg/apperror/codes.go` (+10 lines)
- `pkg/apperror/factory.go` (+65 lines)
- `pkg/apperror/factory_test.go` (+10 lines)

**Total: 161 insertions, 6 deletions**